### PR TITLE
refactor: cartItem 상태에 따른 주문버튼과 장바구니 아이템 조건부 렌더링

### DIFF
--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -4,12 +4,18 @@ import { useEffect, useState } from "react";
 import { useCartStore } from "../store/store";
 import FixedBottomCTA from "../components/FixedBottomCTA";
 import CustomButton from "../components/CustomButton";
+import { useRouter } from "next/navigation";
 
 export default function CartPage() {
-  const { cartItems, addToCart, removeFromCart, updateQuantity } =
-    useCartStore();
+  const {
+    cartItems,
+    completeOrder,
+    addToCart,
+    removeFromCart,
+    updateQuantity,
+  } = useCartStore();
   const [totalPrice, setTotalPrice] = useState(0);
-
+  const router = useRouter();
   useEffect(() => {
     setTotalPrice(
       cartItems.reduce(
@@ -39,7 +45,7 @@ export default function CartPage() {
                         onClick={() => {
                           removeFromCart(item.id);
                         }}
-                        className="size-10 fill-gray-400 hover:fill-gray-500 active:fill-gray-500"
+                        className="size-10 fill-tossgray-500 hover:fill-gray-500 active:fill-gray-500"
                       >
                         <path
                           strokeLinecap="round"
@@ -56,64 +62,69 @@ export default function CartPage() {
                   <div className="flex gap-3 justify-end">
                     <button
                       type="button"
-                      className="hover:bg-gray-300 active:bg-gray-300 transition font-semibold rounded-lg bg-gray-100 text-gray-500 px-4 py-2"
+                      className="hover:bg-gray-300 active:bg-gray-300 transition font-semibold rounded-lg bg-gray-100 text-gray-500 px-4"
                     >
                       옵션 변경
                     </button>
                     <div
                       id="count-button-group"
-                      className="flex items-center px-3 rounded-lg gap-1 bg-gray-100 text-gray-500"
+                      className="flex rounded-xl gap-1 bg-gray-100"
                     >
-                      <button
-                        type="button"
-                        onClick={() => {
-                          updateQuantity(item.id, item.quantity - 1);
-                        }}
-                      >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          strokeWidth="2.5"
-                          className="size-5 stroke-gray-500"
+                      <div id="count-minus" className="flex items-center p-3">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            updateQuantity(item.id, item.quantity - 1);
+                          }}
                         >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M5 12h14"
-                          />
-                        </svg>
-                      </button>
-                      <input
-                        type="number"
-                        value={item.quantity}
-                        min={1}
-                        max={50}
-                        onChange={(e) => {
-                          updateQuantity(item.id, Number(e.target.value));
-                        }}
-                        className="bg-white font-semibold text-gray-600 justify-center text-xl px-6 py-2 my-1 rounded-xl shadow-xs w-12"
-                      />
-                      <button
-                        type="button"
-                        onClick={() => {
-                          updateQuantity(item.id, item.quantity + 1);
-                        }}
+                          <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            strokeWidth="2.5"
+                            className={`size-5 ${
+                              item.quantity <= 1
+                                ? "stroke-gray-300"
+                                : "stroke-gray-500"
+                            }`}
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              d="M5 12h14"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+
+                      <div
+                        id="count-value"
+                        className="justify-center text-center bg-white font-semibold text-gray-600 text-xl py-2 my-1 rounded-xl shadow w-12"
                       >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          strokeWidth="2.5"
-                          className="size-5 stroke-gray-500"
+                        {item.quantity}
+                      </div>
+                      <div id="count-plus" className="flex items-center p-3">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            updateQuantity(item.id, item.quantity + 1);
+                          }}
                         >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M12 4.5v15m7.5-7.5h-15"
-                          />
-                        </svg>
-                      </button>
+                          <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            strokeWidth="2.5"
+                            className="size-5 stroke-gray-500"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              d="M12 4.5v15m7.5-7.5h-15"
+                            />
+                          </svg>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -144,7 +155,13 @@ export default function CartPage() {
             </div>
             <div className="bg-gray-100 h-[16px]"></div>
           </div>
-          <FixedBottomCTA buttonText="주문하기" />
+          <FixedBottomCTA
+            onClick={() => {
+              completeOrder();
+              router.push("/order/history");
+            }}
+            buttonText="주문하기"
+          />
         </>
       ) : (
         <CustomButton>메뉴 추가하기</CustomButton>

--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -2,6 +2,8 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useCartStore } from "../store/store";
+import FixedBottomCTA from "../components/FixedBottomCTA";
+import CustomButton from "../components/CustomButton";
 
 export default function CartPage() {
   const { cartItems, addToCart, removeFromCart, updateQuantity } =
@@ -21,131 +23,132 @@ export default function CartPage() {
     <div id="container" className="font-sans">
       <div id="myMenu" className="px-6 pt-6 pb-4">
         <p className="font-bold mb-5 text-xl">내 메뉴</p>
-        {cartItems.map((item) => (
-          <li key={item.id} className="flex items-center mb-5">
-            <div className="flex flex-col w-full">
-              <div className="flex items-center justify-between text-lg font-medium text-gray-800">
-                <span>{item.name}</span>
-                <button type="button">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    strokeWidth={1.5}
-                    stroke="white"
-                    onClick={() => {
-                      removeFromCart(item.id);
-                    }}
-                    className="size-10 fill-gray-400 hover:fill-gray-500 active:fill-gray-500"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="m9.75 9.75 4.5 4.5m0-4.5-4.5 4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
-                    />
-                  </svg>
-                </button>
-              </div>
-              <div className="text-lg font-semibold mb-4 text-gray-800">
-                {item.price.toLocaleString()}원
-              </div>
+        {cartItems.length ? (
+          <div id="items-group">
+            {cartItems.map((item) => (
+              <li key={item.id} className="flex items-center mb-5">
+                <div className="flex flex-col w-full">
+                  <div className="flex items-center justify-between text-lg font-medium text-gray-800">
+                    <span>{item.name}</span>
+                    <button type="button">
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        strokeWidth={1.5}
+                        stroke="white"
+                        onClick={() => {
+                          removeFromCart(item.id);
+                        }}
+                        className="size-10 fill-gray-400 hover:fill-gray-500 active:fill-gray-500"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="m9.75 9.75 4.5 4.5m0-4.5-4.5 4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                  <div className="text-lg font-semibold mb-4 text-gray-800">
+                    {(item.quantity * item.price).toLocaleString()}원
+                  </div>
 
-              <div className="flex gap-3 justify-end">
-                <button
-                  type="button"
-                  className="hover:bg-gray-300 active:bg-gray-300 transition font-semibold rounded-lg bg-gray-100 text-gray-500 px-4 py-2"
-                >
-                  옵션 변경
-                </button>
-                <div
-                  id="count-button-group"
-                  className="flex items-center px-3 rounded-lg gap-1 bg-gray-100 text-gray-500"
-                >
-                  <button
-                    type="button"
-                    onClick={() => {
-                      updateQuantity(item.id, item.quantity - 1);
-                    }}
-                  >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      strokeWidth="2.5"
-                      className="size-5 stroke-gray-500"
+                  <div className="flex gap-3 justify-end">
+                    <button
+                      type="button"
+                      className="hover:bg-gray-300 active:bg-gray-300 transition font-semibold rounded-lg bg-gray-100 text-gray-500 px-4 py-2"
                     >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M5 12h14"
-                      />
-                    </svg>
-                  </button>
-                  <input
-                    type="number"
-                    value={item.quantity ?? 1}
-                    min={1}
-                    max={50}
-                    onChange={(e) => {
-                      updateQuantity(item.id, Number(e.target.value));
-                    }}
-                    className="bg-white font-semibold text-gray-600 justify-center text-center text-lg px-6 py-2 my-1 rounded-xl shadow-xs w-12"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => {
-                      updateQuantity(item.id, item.quantity + 1);
-                    }}
-                  >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      strokeWidth="2.5"
-                      className="size-5 stroke-gray-500"
+                      옵션 변경
+                    </button>
+                    <div
+                      id="count-button-group"
+                      className="flex items-center px-3 rounded-lg gap-1 bg-gray-100 text-gray-500"
                     >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M12 4.5v15m7.5-7.5h-15"
+                      <button
+                        type="button"
+                        onClick={() => {
+                          updateQuantity(item.id, item.quantity - 1);
+                        }}
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          strokeWidth="2.5"
+                          className="size-5 stroke-gray-500"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M5 12h14"
+                          />
+                        </svg>
+                      </button>
+                      <input
+                        type="number"
+                        value={item.quantity}
+                        min={1}
+                        max={50}
+                        onChange={(e) => {
+                          updateQuantity(item.id, Number(e.target.value));
+                        }}
+                        className="bg-white font-semibold text-gray-600 justify-center text-xl px-6 py-2 my-1 rounded-xl shadow-xs w-12"
                       />
-                    </svg>
-                  </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          updateQuantity(item.id, item.quantity + 1);
+                        }}
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          strokeWidth="2.5"
+                          className="size-5 stroke-gray-500"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M12 4.5v15m7.5-7.5h-15"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
                 </div>
-              </div>
-            </div>
-          </li>
-        ))}
+              </li>
+            ))}
+          </div>
+        ) : (
+          <p className="text-tossgray-500">담은 메뉴가 없어요</p>
+        )}
       </div>
 
-      <div
-        id="go-to-menu-group"
-        className="hover:bg-gray-200 active:bg-gray-200"
-      >
-        <div className="h-px bg-gray-200"></div>
-        <div className="flex justify-center my-3">
-          <Link
-            href="/"
-            className=" text-blue-500 text-lg font-medium hover:bg-gray-300 rounded-lg py-2 px-4
-            active:text-sm transition-transform duration-100"
-            style={{ minHeight: "44px" }}
+      {cartItems.length > 0 ? (
+        <>
+          <div
+            id="go-to-menu-group"
+            className="hover:bg-gray-200 active:bg-gray-200"
           >
-            메뉴 더 추가 +
-          </Link>
-        </div>
-        <div className="bg-gray-100 h-[16px]"></div>
-      </div>
-
-      <div
-        id="order-button-group"
-        className="font-medium text-lg fixed bottom-0 left-0 right-0 px-4 pb-4"
-      >
-        <button className="flex justify-center items-center mx-auto w-full bg-blue-500 rounded-xl text-white px-4 py-2 hover:bg-blue-600 active:bg-blue-600">
-          <span className="mr-2 font-semibold text-sm bg-white text-blue-500 px-2 py-0.5 rounded-lg">
-            {cartItems.reduce((acc, item) => acc + item.quantity, 0)}
-          </span>
-          <span>{totalPrice.toLocaleString()}</span>원 주문하기
-        </button>
-      </div>
+            <div className="h-px bg-gray-200"></div>
+            <div className="flex justify-center my-3">
+              <Link
+                href="/"
+                className=" text-blue-500 text-lg font-medium hover:bg-gray-300 rounded-lg py-2 px-4
+            active:text-sm transition-transform duration-100"
+                style={{ minHeight: "44px" }}
+              >
+                메뉴 더 추가 +
+              </Link>
+            </div>
+            <div className="bg-gray-100 h-[16px]"></div>
+          </div>
+          <FixedBottomCTA buttonText="주문하기" />
+        </>
+      ) : (
+        <CustomButton>메뉴 추가하기</CustomButton>
+      )}
     </div>
   );
 }

--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -28,13 +28,14 @@ export default function CartPage() {
   return (
     <div id="container" className="font-sans">
       <div id="myMenu" className="px-6 pt-6 pb-4">
-        <p className="font-bold mb-5 text-xl">내 메뉴</p>
+        <p className="font-semibold mb-5 text-xl">내 메뉴</p>
+        {/* 장바구니 1개 이상이면 아이템 보여주기*/}
         {cartItems.length ? (
           <div id="items-group">
             {cartItems.map((item) => (
               <li key={item.id} className="flex items-center mb-5">
                 <div className="flex flex-col w-full">
-                  <div className="flex items-center justify-between text-lg font-medium text-gray-800">
+                  <div className="flex items-center justify-between text-lg font-normal text-gray-800">
                     <span>{item.name}</span>
                     <button type="button">
                       <svg
@@ -45,7 +46,7 @@ export default function CartPage() {
                         onClick={() => {
                           removeFromCart(item.id);
                         }}
-                        className="size-10 fill-tossgray-500 hover:fill-gray-500 active:fill-gray-500"
+                        className="size-10 fill-tossgray-300 hover:fill-gray-500 active:fill-gray-500"
                       >
                         <path
                           strokeLinecap="round"
@@ -62,13 +63,13 @@ export default function CartPage() {
                   <div className="flex gap-3 justify-end">
                     <button
                       type="button"
-                      className="hover:bg-gray-300 active:bg-gray-300 transition font-semibold rounded-lg bg-gray-100 text-gray-500 px-4"
+                      className="hover:bg-gray-300 active:bg-gray-300 transition font-medium rounded-lg bg-tossgray-400 text-tossgray-600 px-4"
                     >
                       옵션 변경
                     </button>
                     <div
                       id="count-button-group"
-                      className="flex rounded-xl gap-1 bg-gray-100"
+                      className="flex rounded-xl gap-1 bg-tossgray-400"
                     >
                       <div id="count-minus" className="flex items-center p-3">
                         <button
@@ -99,7 +100,7 @@ export default function CartPage() {
 
                       <div
                         id="count-value"
-                        className="justify-center text-center bg-white font-semibold text-gray-600 text-xl py-2 my-1 rounded-xl shadow w-12"
+                        className="justify-center text-center bg-white font-medium text-gray-800 text-xl py-2 my-1 rounded-xl shadow w-12"
                       >
                         {item.quantity}
                       </div>
@@ -132,10 +133,12 @@ export default function CartPage() {
             ))}
           </div>
         ) : (
+          //장바구니 비었을때 표시
           <p className="text-tossgray-500">담은 메뉴가 없어요</p>
         )}
       </div>
 
+      {/* 장바구니 0개면 메뉴추가하기, 1개 이상이면 주문하기 버튼 */}
       {cartItems.length > 0 ? (
         <>
           <div
@@ -146,7 +149,7 @@ export default function CartPage() {
             <div className="flex justify-center my-3">
               <Link
                 href="/"
-                className=" text-blue-500 text-lg font-medium hover:bg-gray-300 rounded-lg py-2 px-4
+                className=" text-blue-500 text-lg font-normal hover:bg-gray-300 rounded-lg py-2 px-4
             active:text-sm transition-transform duration-100"
                 style={{ minHeight: "44px" }}
               >

--- a/app/globals.css
+++ b/app/globals.css
@@ -41,6 +41,7 @@
   --color-tossgray-600: #6b7684;
   --color-tossgray-500: #8b95a1;
   --color-tossgray-400: #f2f4f6;
+  --color-tossgray-300: #b0b8c1;
   --color-tossblue-500: #3182f6;
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -51,12 +51,12 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
+/* @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;
     --foreground: #ededed;
   }
-}
+} */
 
 body {
   background: var(--background);


### PR DESCRIPTION
### 개요

**작업사항**

1. 주문하기 버튼 공통컴포넌트 FixedBottomCTA로 수정
2. 장바구니 개수에 따라 조건부 렌더링
- 주문하기/ 메뉴추가하기 버튼으로 구분
- 담은 메뉴가없어요 / 장바구니 아이템 보여주기로 구분
- 비어있으면 '담은 메뉴가 없어요' & 메뉴추가하기 버튼 보이기
- 1개이상이면 메뉴더추가 & 주문하기 버튼 보이기
3. global.css에 gray-300 추가 
4. 담은 수량 안보임 문제 해결