### PR TITLE
feat: 주문완료 페이지 추가

### DIFF
--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -148,8 +148,9 @@ export default function CartPage() {
           </div>
           <FixedBottomCTA
             onClick={() => {
+              //TODO: 모달창 띄우기
               completeOrder();
-              router.push("/order/history");
+              router.push("/order/complete");
             }}
             buttonText="주문하기"
           />

--- a/app/components/FixedBottomCTA.tsx
+++ b/app/components/FixedBottomCTA.tsx
@@ -50,7 +50,7 @@ export default function FixedBottomCTA({
   }
 
   return (
-    <div className="fixed left-0 right-0 bottom-0 p-6 h-[112px] flex justify-center items-center bg-white z-49">
+    <div className="fixed left-0 right-0 bottom-0 p-6 h-[112px] flex justify-center items-center bg-linear-to-t from-white from-75% to-transparent z-49">
       <button
         onClick={handleClick}
         className="py-3 w-full font-semibold text-xl text-white text-center rounded-2xl bg-tossblue-500 max-w-md animate-custom animate-duration-[1s] animate-ease-[cubic-bezier(0.25,0.1,0.25,1)]"

--- a/app/components/MainHeader.tsx
+++ b/app/components/MainHeader.tsx
@@ -8,6 +8,7 @@ import CallButton from "./CallButton";
 export default function MainHeader() {
   const router = useRouter();
   const pathname = usePathname();
+  if (pathname === "/order/complete") return;
   if (pathname === "/order/history") {
     return (
       <div className="flex items-center p-3 text-slate-600">

--- a/app/order/complete/loading.tsx
+++ b/app/order/complete/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <>로딩중...</>;
+}

--- a/app/order/complete/page.tsx
+++ b/app/order/complete/page.tsx
@@ -1,3 +1,58 @@
+"use client";
+import Image from "next/image";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import Progress from "./progress";
+
 export default function CompletePage() {
-  return <div>Complete page</div>;
+  const [isLoading, setLoading] = useState(true);
+
+  //주문중...먼저 3초간 로딩 후, 주문완료 페이지 렌더링
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setLoading((pre) => !pre);
+    }, 3000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (isLoading) {
+    return (
+      <>
+        <Progress />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <article className="p-6 mb-[112px]">
+        <div className="flex justify-between">
+          <div className="flex flex-col">
+            <span className="text-[28px] font-semibold text-tossgray-900">
+              주문을 완료했어요
+            </span>
+            <span className="text-15 font-normal text-[#f04452]">
+              나갈 때 직접 결제, 잊지 마세요.
+            </span>
+          </div>
+          <Image
+            alt="clap"
+            width={60}
+            height={60}
+            src="https://static.toss.im/3d-emojis/u1F44F-apng.png"
+            aria-hidden="true"
+          />
+        </div>
+        {/* TODO: 주문 내역 추가예정 */}
+      </article>
+      <div className="fixed left-0 right-0 bottom-0 p-6 h-[112px] flex justify-center items-center bg-white z-50">
+        <button className="py-4 w-full text-17 font-semibold text-xl text-white text-center rounded-2xl bg-tossblue-500 max-w-md">
+          <Link href="/" className="flex gap-2 justify-center items-center">
+            메뉴판으로
+          </Link>
+        </button>
+      </div>
+    </>
+  );
 }

--- a/app/order/complete/progress.tsx
+++ b/app/order/complete/progress.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function Progress() {
+  const [showMessage, setMessage] = useState("first");
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setMessage(() => "second");
+    }, 1000);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, []);
+
+  return (
+    <div className="flex p-6 h-screen justify-center">
+      <div className="flex flex-col items-center  text-center font-bold text-[30px] justify-center">
+        <p className="animate-fade-up" key={showMessage}>
+          {showMessage === "first" ? (
+            "주문 넣는 중..."
+          ) : (
+            <>
+              결제는 나갈 때, <br />
+              잊지마세요!
+            </>
+          )}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,7 @@ const nextConfig: NextConfig = {
         hostname: "ptrgxcgkobowwhhliveh.supabase.co",
         pathname: "**",
       },
+      new URL("https://static.toss.im/3d-emojis/u1F44F-apng.png"),
     ],
   },
 };


### PR DESCRIPTION
### **작업사항**
1. 주문완료 페이지 추가
- MainHeader 노출 안되게 설정
- '주문넣는중'이 먼저 3초간 보임 > 주문완료 페이지로 넘어감
- 주문내역 내용 추가예정
2. FixedBottomCTA 배경 흰색 그라데이션 추가 
