### PR TITLE
feat: 주문 상세내역 OrderHistory컴포넌트로 분리

### DIFF
--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -7,8 +7,7 @@ import { useRouter } from "next/navigation";
 import { useToastStore } from "../store/toastStore";
 
 export default function CartPage() {
-  const { cartItems, completeOrder, removeFromCart, updateQuantity } =
-    useCartStore();
+  const { cartItems, removeFromCart, updateQuantity } = useCartStore();
   const addToast = useToastStore((state) => state.addToast);
   const router = useRouter();
 
@@ -149,7 +148,6 @@ export default function CartPage() {
           <FixedBottomCTA
             onClick={() => {
               //TODO: 모달창 띄우기
-              completeOrder();
               router.push("/order/complete");
             }}
             buttonText="주문하기"

--- a/app/components/CallButton.tsx
+++ b/app/components/CallButton.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { useEffect, useState } from "react";
+import { useToastStore } from "../store/toastStore";
 
 const callOptions = ["물", "냅킨", "직원부르기"];
 
@@ -9,6 +10,7 @@ export default function CallButton() {
   const [modalStatus, setModalStatus] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
   const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
+  const addToast = useToastStore((state) => state.addToast);
 
   const onHandleModalStatus = () => {
     if (modalStatus) {
@@ -39,6 +41,7 @@ export default function CallButton() {
     setModalStatus(false);
     setSelectedOptions([]);
     // 호출하기 로직 추가 (API 호출)
+    addToast("호출했어요", "success");
   };
 
   useEffect(() => {

--- a/app/components/OrderHistory.tsx
+++ b/app/components/OrderHistory.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from "react";
+import { useCartStore } from "../store/store";
+
+export default function OrderHistory() {
+  const orderHistory = useCartStore((state) => state.getOrderHistory());
+
+  // 전체 주문 수량 계산
+  const totalItems = orderHistory.reduce(
+    (total, order) =>
+      total + order.items.reduce((sum, item) => sum + item.quantity, 0),
+    0
+  );
+
+  const totalPrice = orderHistory
+    .reduce((total, order) => total + order.totalPrice, 0)
+    .toLocaleString();
+
+  const [displayTotalItems, setDisplayAmount] = useState(totalItems || 0);
+  const [displayTotalPrice, setDisplayPrice] = useState(totalPrice || "0");
+  const [shouldRender, setShouldRender] = useState(false);
+
+  useEffect(() => {
+    if (totalItems !== undefined && totalPrice !== undefined) {
+      setDisplayAmount(totalItems);
+      setDisplayPrice(totalPrice);
+      setShouldRender(true);
+    } else {
+      setShouldRender(false);
+    }
+  }, [totalItems, totalPrice]);
+
+  if (!shouldRender) {
+    return null;
+  }
+
+  return (
+    <>
+      {totalItems === 0 ? (
+        <div className="pt-6">
+          <span className="font-medium text-17 text-tossgray-500">
+            아직 주문 내역이 없어요
+          </span>
+        </div>
+      ) : (
+        <>
+          <div className="pt-6">
+            <span className="text-22 font-bold text-tossgray-900">
+              총 {displayTotalItems}개 | {displayTotalPrice}원
+            </span>
+          </div>
+          {orderHistory.map((order, index) => {
+            const totalItems = order.items.reduce(
+              (total, item) => total + item.quantity,
+              0
+            );
+            return (
+              <div key={order.id}>
+                <div className="flex justify-between mt-6 mb-5">
+                  <span className="text-tossgray-800 text-17 font-bold">
+                    {index === 0 ? "최근" : "이전"} 주문 내역 ({totalItems}개)
+                  </span>
+                  <span className="text-tossgray-700 text-15">
+                    {order.orderTime}
+                  </span>
+                </div>
+                <div className="flex flex-col gap-3">
+                  {order.items.map((item) => (
+                    <div className="flex flex-col" key={item.id}>
+                      <span
+                        key={item.id}
+                        className="text-tossgray-800 font-bold text-17"
+                      >
+                        {item.name} × {item.quantity}
+                      </span>
+                      <span className="text-15 text-tossgray-700">
+                        {item.price.toLocaleString()}원
+                      </span>
+                    </div>
+                  ))}
+                </div>
+                {index !== orderHistory.length - 1 ? (
+                  <hr className="my-6 text-tossgray-400" />
+                ) : null}
+              </div>
+            );
+          })}
+        </>
+      )}
+    </>
+  );
+}

--- a/app/order/complete/page.tsx
+++ b/app/order/complete/page.tsx
@@ -3,18 +3,22 @@ import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import Progress from "./progress";
+import { useCartStore } from "@/app/store/store";
+import OrderHistory from "@/app/components/OrderHistory";
 
 export default function CompletePage() {
   const [isLoading, setLoading] = useState(true);
+  const { completeOrder } = useCartStore();
 
   //주문중...먼저 3초간 로딩 후, 주문완료 페이지 렌더링
 
   useEffect(() => {
+    completeOrder();
     const timer = setTimeout(() => {
       setLoading((pre) => !pre);
     }, 3000);
     return () => clearTimeout(timer);
-  }, []);
+  }, [completeOrder]);
 
   if (isLoading) {
     return (
@@ -44,8 +48,9 @@ export default function CompletePage() {
             aria-hidden="true"
           />
         </div>
-        {/* TODO: 주문 내역 추가예정 */}
+        <OrderHistory />
       </article>
+      
       <div className="fixed left-0 right-0 bottom-0 p-6 h-[112px] flex justify-center items-center bg-white z-50">
         <button className="py-4 w-full text-17 font-semibold text-xl text-white text-center rounded-2xl bg-tossblue-500 max-w-md">
           <Link href="/" className="flex gap-2 justify-center items-center">

--- a/app/order/history/page.tsx
+++ b/app/order/history/page.tsx
@@ -1,41 +1,9 @@
 "use client";
 
-import { useCartStore } from "@/app/store/store";
+import OrderHistory from "@/app/components/OrderHistory";
 import Link from "next/link";
-import { useEffect, useState } from "react";
 
 export default function HistoryPage() {
-  const orderHistory = useCartStore((state) => state.getOrderHistory());
-
-  // 전체 주문 수량 계산
-  const totalItems = orderHistory.reduce(
-    (total, order) =>
-      total + order.items.reduce((sum, item) => sum + item.quantity, 0),
-    0
-  );
-
-  const totalPrice = orderHistory
-    .reduce((total, order) => total + order.totalPrice, 0)
-    .toLocaleString();
-
-  const [displayTotalItems, setDisplayAmount] = useState(totalItems || 0);
-  const [displayTotalPrice, setDisplayPrice] = useState(totalPrice || "0");
-  const [shouldRender, setShouldRender] = useState(false);
-
-  useEffect(() => {
-    if (totalItems !== undefined && totalPrice !== undefined) {
-      setDisplayAmount(totalItems);
-      setDisplayPrice(totalPrice);
-      setShouldRender(true);
-    } else {
-      setShouldRender(false);
-    }
-  }, [totalItems, totalPrice]);
-
-  if (!shouldRender) {
-    return null;
-  }
-
   return (
     <>
       <article className="p-6 mb-[112px]">
@@ -47,58 +15,7 @@ export default function HistoryPage() {
             나갈 때 직접 결제, 잊지 마세요.
           </span>
         </div>
-
-        {totalItems === 0 ? (
-          <div className="pt-6">
-            <span className="font-medium text-17 text-tossgray-500">
-              아직 주문 내역이 없어요
-            </span>
-          </div>
-        ) : (
-          <>
-            <div className="pt-6">
-              <span className="text-22 font-bold text-tossgray-900">
-                {displayTotalItems}개 | {displayTotalPrice}원
-              </span>
-            </div>
-            {orderHistory.map((order, index) => {
-              const totalItems = order.items.reduce(
-                (total, item) => total + item.quantity,
-                0
-              );
-              return (
-                <div key={order.id}>
-                  <div className="flex justify-between mt-6 mb-5">
-                    <span className="text-tossgray-800 text-17 font-bold">
-                      {index === 0 ? "최근" : "이전"} 주문 내역 ({totalItems}개)
-                    </span>
-                    <span className="text-tossgray-700 text-15">
-                      {order.orderTime}
-                    </span>
-                  </div>
-                  <div className="flex flex-col gap-3">
-                    {order.items.map((item) => (
-                      <div className="flex flex-col" key={item.id}>
-                        <span
-                          key={item.id}
-                          className="text-tossgray-800 font-bold text-17"
-                        >
-                          {item.name} × {item.quantity}
-                        </span>
-                        <span className="text-15 text-tossgray-700">
-                          {item.price.toLocaleString()}원
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                  {index !== orderHistory.length - 1 ? (
-                    <hr className="my-6 text-tossgray-400" />
-                  ) : null}
-                </div>
-              );
-            })}
-          </>
-        )}
+        <OrderHistory />
       </article>
       <div className="fixed left-0 right-0 bottom-0 p-6 h-[112px] flex justify-center items-center bg-white z-50">
         <button className="py-4 w-full text-17 font-semibold text-xl text-white text-center rounded-2xl bg-tossblue-500 max-w-md">


### PR DESCRIPTION
**작업사항**
1. 주문내역 페이지 내 상세내역 부분을 공통컴포넌트 OrderHistory로 분리 - 주문내역, 주문완료 페이지에서 공유
2. 주문완료 페이지 이동시 장바구니가 먼저 노출되는 문제 수정
3. 직원호출하기 버튼 클릭시 호출했어요 토스트 추가