### PR TITLE
refactor: 카트 페이지 수량 업데이트 로직 개선 및 updatedBy 필드 추가

### DIFF
--- a/app/components/SetupUserChannel.tsx
+++ b/app/components/SetupUserChannel.tsx
@@ -4,7 +4,7 @@ import { createClient } from "@/utils/supabase/client";
 import { useEffect } from "react";
 import { useChannelStore } from "../store/channelStore";
 import { useUserStore } from "../store/userStore";
-// import { nanoid } from "nanoid";
+import { nanoid } from "nanoid";
 import { getLocalStorage, setLocalStorage } from "@/utils/storage";
 
 export default function SetupUserChannel() {
@@ -18,7 +18,7 @@ export default function SetupUserChannel() {
     let userId = getLocalStorage("userId");
 
     if (!userId) {
-      userId = crypto.randomUUID();
+      userId = nanoid();
       setLocalStorage("userId", userId);
     }
     const tableChannel = supabase.channel("user", {


### PR DESCRIPTION
- 수량 변경 시 사용자 ID를 updatedBy 필드에 저장
- 수량 변경 시 토스트 메시지 로직 수정
- 이전 상태 업데이트 로직 개선 및 불필요한 주석 제거
- SetupUserChannel에서 userId 생성 방식을 nanoid로 변경